### PR TITLE
Add portpair to port-forward command key

### DIFF
--- a/main.go
+++ b/main.go
@@ -165,7 +165,7 @@ func Run(cmd *cobra.Command, args []string) error {
 					addcmd = exec.Command("kubectl", "--context", ctx, "port-forward", "-n", parts[1], rctype+"/"+targetList[0], portpair)
 				}
 
-				key := fmt.Sprintf("%s:%s:%s", ctx, parts[1], name)
+				key := fmt.Sprintf("%s:%s:%s:%s", ctx, parts[1], name, portpair)
 				if _, ok := cs[key]; !ok {
 					cs[key] = addcmd
 				}


### PR DESCRIPTION
This allows for multiple commands that forward different ports on the same
service.  This is useful when a service exposes multiple ports you'd like
to forward.

Addresses #5 